### PR TITLE
各タイトルのセクションページによるアクセシビリティ改善

### DIFF
--- a/content/docs/ロックマンエグゼ/_index.md
+++ b/content/docs/ロックマンエグゼ/_index.md
@@ -1,4 +1,8 @@
 ---
 bookCollapseSection: true
-weight: 20
+weight: 10
 ---
+
+# ロックマンエグゼ
+
+{{<suzaku-section>}}

--- a/content/docs/ロックマンエグゼ2/_index.md
+++ b/content/docs/ロックマンエグゼ2/_index.md
@@ -2,3 +2,7 @@
 bookCollapseSection: true
 weight: 20
 ---
+
+# ロックマンエグゼ2
+
+{{<suzaku-section>}}

--- a/content/docs/ロックマンエグゼ3/_index.md
+++ b/content/docs/ロックマンエグゼ3/_index.md
@@ -1,4 +1,8 @@
 ---
 bookCollapseSection: true
-weight: 20
+weight: 30
 ---
+
+# ロックマンエグゼ3
+
+{{<suzaku-section>}}

--- a/content/docs/ロックマンエグゼ4/_index.md
+++ b/content/docs/ロックマンエグゼ4/_index.md
@@ -1,4 +1,8 @@
 ---
 bookCollapseSection: true
-weight: 20
+weight: 40
 ---
+
+# ロックマンエグゼ4
+
+{{<suzaku-section>}}

--- a/content/docs/ロックマンエグゼ5/_index.md
+++ b/content/docs/ロックマンエグゼ5/_index.md
@@ -1,4 +1,8 @@
 ---
 bookCollapseSection: true
-weight: 20
+weight: 50
 ---
+
+# ロックマンエグゼ5
+
+{{<suzaku-section>}}

--- a/content/docs/ロックマンエグゼ6/_index.md
+++ b/content/docs/ロックマンエグゼ6/_index.md
@@ -1,4 +1,8 @@
 ---
 bookCollapseSection: true
-weight: 20
+weight: 60
 ---
+
+# ロックマンエグゼ6
+
+{{<suzaku-section>}}

--- a/layouts/shortcodes/suzaku-section.html
+++ b/layouts/shortcodes/suzaku-section.html
@@ -1,0 +1,39 @@
+{{/*
+  セクション内コンテンツをすべて展開してリンクを貼る
+  cf) themes\hugo-book\layouts\partials\docs\menu-filetree.html
+*/}}
+
+{{ template "suzaku-section-children" (dict "Section" .Page "CurrentPage" .Page) }}
+
+{{ define "suzaku-section-children" }}{{/* (dict "Section" .Section "CurrentPage" .CurrentPage) */}}
+  <ul>
+    {{ range (where .Section.Pages "Params.bookhidden" "ne" true) }}
+      {{ if .IsSection }}
+        <li>
+          {{ template "suzaku-page-link" (dict "Page" . "CurrentPage" $.CurrentPage) }}
+          {{ template "suzaku-section-children" (dict "Section" . "CurrentPage" $.CurrentPage) }}
+        </li>
+      {{ else if and .IsPage .Content }}
+        <li>
+          {{ template "suzaku-page-link" (dict "Page" . "CurrentPage" $.CurrentPage) }}
+        </li>
+      {{ end }}
+    {{ end }}
+  </ul>
+{{ end }}
+
+{{ define "suzaku-page-link" }}{{/* (dict "Page" .Page "CurrentPage" .CurrentPage) */}}
+  {{ $current := eq .CurrentPage .Page }}
+
+  {{ if .Page.Params.BookHref }}
+    <a href="{{ .Page.Params.BookHref }}" class="{{ if $current }}active{{ end }}" target="_blank" rel="noopener">
+      {{- partial "docs/title" .Page -}}
+    </a>
+  {{ else if .Page.Content }}
+    <a href="{{ .Page.RelPermalink }}" class="{{ if $current }}active{{ end }}">
+      {{- partial "docs/title" .Page -}}
+    </a>
+  {{ else }}
+    <span>{{- partial "docs/title" .Page -}}</span>
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
メニューが閉じていることでアクセシビリティの悪さを感じたため、下記の改善を試みました。

- メニューから各タイトルのセクションページへのリンクを有効にした
- 各タイトルのセクションページには、すべてのサブコンテンツへのリンクを表示した

`Book (hugo-book)` テーマだと、中身が空のセクションページにはメニューからリンクが張られない挙動のようです。該当する実装は `themes\hugo-book\layouts\partials\docs\menu-filetree.html` にあります。中身さえあればリンクが張られます。

該当テンプレートを参考に、すべてのサブコンテンツを再帰的に辿ってリストでリンクを貼るショートコード `suzaku-section` を実装し、各タイトルのセクションページに配置しました。これでタイトル別にサブコンテンツを俯瞰できるようになります。

似たような機能として、同テーマの `section` ショートコードがありましたが、直下のコンテンツの Description または Summary を並べるもので、あまり使い勝手がよくなかったためこうしました。

![image](https://user-images.githubusercontent.com/1317492/235412571-f808b58c-80fa-4944-a6bd-5c95d2bed6e5.png)
